### PR TITLE
Clarify Windows Download instructions

### DIFF
--- a/doc/docs/cli-installation.md
+++ b/doc/docs/cli-installation.md
@@ -38,6 +38,7 @@ On Windows, use
 > bitsadmin /transfer cs-cli https://git.io/coursier-cli-windows-exe "%cd%\cs.exe"
 > .\cs --help
 ```
+Note that this must be run with `cmd.exe`, not `PowerShell`.
 
 ## JAR-based launcher
 


### PR DESCRIPTION
Adding a note that bitsadmin needs to be run under cmd. This confused me, and another user in #1744